### PR TITLE
Test whether big/little endian using newer constructs.

### DIFF
--- a/libnuml/CMakeLists.txt
+++ b/libnuml/CMakeLists.txt
@@ -549,12 +549,9 @@ check_include_files (stdlib.h STDC_HEADERS)
 check_include_files (string.h STDC_HEADERS)
 
 set(WORDS_BIGENDIAN)
-if (UNIX)
-  include (TestBigEndian)
-  test_big_endian(WORDS_BIGENDIAN)
+if(CMAKE_C_BYTE_ORDER STREQUAL "BIG_ENDIAN")
+  set(WORDS_BIGENDIAN TRUE)
 else()
-  # test_big_endian seems to fail with nmake (VS 2010) on windows
-  # however, windows is always little endian, so catch this here
   set(WORDS_BIGENDIAN FALSE)
 endif()
 


### PR DESCRIPTION
For some reason, Windows WSL/Ubuntu didn't work with the older method (which I believe is now deprecated); use the newer 'CMAKE_C_BYTE_ORDER' instead.